### PR TITLE
Feat: target configuration + event-factory support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  -  Feat: target configuration + event-factory support [#6](https://github.com/logstash-plugins/logstash-codec-edn_lines/pull/6)
+
 ## 3.0.6
   - Update gemspec summary
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -21,3 +21,37 @@ include::{include_path}/plugin_header.asciidoc[]
 ==== Description
 
 Reads and produces newline-delimited EDN format data.
+
+[id="plugins-{type}s-{plugin}-options"]
+==== Edn_lines Codec configuration options
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
+|=======================================================================
+
+&nbsp;
+
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+  * The option is only relevant while decoding.
+
+Define the target field for placing the decoded fields.
+If this setting is not set, data will be stored at the root (top level) of the event.
+
+For example, if you want data to be put under the `document` field:
+[source,ruby]
+    input {
+      tcp {
+        port => 4242
+        codec => edn_lines {
+          target => "[document]"
+        }
+      }
+    }
+
+

--- a/lib/logstash/codecs/edn_lines.rb
+++ b/lib/logstash/codecs/edn_lines.rb
@@ -2,9 +2,22 @@ require "logstash/codecs/base"
 require "logstash/codecs/line"
 require "logstash/util"
 
+require 'logstash/plugin_mixins/event_support/event_factory_adapter'
+require 'logstash/plugin_mixins/validator_support/field_reference_validation_adapter'
+
 class LogStash::Codecs::EDNLines < LogStash::Codecs::Base
+
+  extend LogStash::PluginMixins::ValidatorSupport::FieldReferenceValidationAdapter
+
+  include LogStash::PluginMixins::EventSupport::EventFactoryAdapter
+
   config_name "edn_lines"
 
+  # Defines a target field for placing decoded fields.
+  # If this setting is omitted, data gets stored at the root (top level) of the event.
+  #
+  # NOTE: the target is only relevant while decoding data into a new event.
+  config :target, :validate => :field_reference
 
   def register
     require "edn"
@@ -20,10 +33,10 @@ class LogStash::Codecs::EDNLines < LogStash::Codecs::Base
   def decode(data)
     @lines.decode(data) do |event|
       begin
-        yield LogStash::Event.new(EDN.read(event.get("message")))
+        yield targeted_event_factory.new_event(EDN.read(event.get("message")))
       rescue => e
         @logger.warn("EDN parse failure. Falling back to plain-text", :error => e, :data => data)
-        yield LogStash::Event.new("message" => data)
+        yield event_factory.new_event("message" => data)
       end
     end
   end

--- a/logstash-codec-edn_lines.gemspec
+++ b/logstash-codec-edn_lines.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-edn_lines'
-  s.version         = '3.0.6'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads newline-delimited EDN format data"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-event_support', '~> 1.0'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
 
   s.add_runtime_dependency 'logstash-codec-line'
   s.add_runtime_dependency 'edn'


### PR DESCRIPTION
Added `target` option for placing decoded fields (to help users with ECS migration) and started using `event_factory` support.